### PR TITLE
Move env prefix into environment variable config

### DIFF
--- a/command-system.js
+++ b/command-system.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
+const stateUtils = require('./utils/state-utils');
 
 module.exports = function CommandSystem() {
   // Specify the bot command prefix
-  const commandPrefix = ',';
+  const commandPrefix = stateUtils.getBotCommandPrefix();
   // Initialize an object to hold the list of commands
   var commandTable = {};
 

--- a/env.example
+++ b/env.example
@@ -1,3 +1,4 @@
+BOT_PREFIX=","
 BOT_NAME="Dragon Sword"
 DB_URL=mongodb://localhost:27017/dragonsworddev
 DB_USER=databaseAccountUsername

--- a/utils/state-utils.js
+++ b/utils/state-utils.js
@@ -48,4 +48,12 @@ function getBotName() {
   return process.env.BOT_NAME;
 }
 
-module.exports = { setGameState, getGameChannels, getGameMasters, getBotName };
+/**
+ * Retrieves the bot's command prefix
+ * @returns {String}
+ */
+function getBotCommandPrefix() {
+	return process.env.BOT_PREFIX;
+}
+
+module.exports = { setGameState, getGameChannels, getGameMasters, getBotName, getBotCommandPrefix };


### PR DESCRIPTION
Bot now uses environment variable BOT_PREFIX to configure the prefix it looks for in discord messages