### PR TITLE
Add rejection message to debug command

### DIFF
--- a/commands/debug-game.js
+++ b/commands/debug-game.js
@@ -19,4 +19,7 @@ exports.run = (client, message, args) => {
       );
     });
   }
+  else {
+	  message.channel.send('You do not have permission to use this command.');
+  }
 };


### PR DESCRIPTION
Debug command now displays a rejection message if the user calling the command does not have permission to use it.